### PR TITLE
improve(tests): Do not flatten tests to allow nix-unit run specific suite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,21 +33,6 @@ let
       ) {} entries;
     in files // dirs;
 
-  # -- collectTests: inline test extraction from raw tree --
-  #
-  # Walk the raw mk-wrapped tree, applying api.extractTests to file results
-  # and recursing into directory attrsets. Produces flat test attrset with
-  # dotted prefixes: { "kernel.pure-bind-applies-f" = { expr; expected; }; ... }
-  collectTests = prefix: tree:
-    lib.foldlAttrs (acc: name: node:
-      let p = if prefix == "" then name else "${prefix}.${name}"; in
-      if node ? _type && node._type == "nix-effects-api"
-      then acc // api.extractTests p node
-      else if builtins.isAttrs node && !(node ? _tag)
-      then acc // collectTests p node
-      else acc
-    ) {} tree;
-
   # -- Library fixpoint via lib.fix --
   #
   # Single fixpoint producing both the raw mk-wrapped tree (for test extraction)
@@ -162,15 +147,20 @@ let
   };
 
   integrationTests = import ./tests { inherit lib fx; };
-  inlineTests = collectTests "" internals.raw;
+  inlineTests = api.extractTests internals.raw;
 
   # nix-unit compatible test attrset. nix-unit requires the "test" prefix on
   # test case attrs; non-prefixed attrs are recursed into as namespaces.
   # We use the module/directory structure as namespaces and prefix leaf tests.
-  prefixTests = lib.mapAttrs' (name: value: {
-    name = "test ${name}";
+  prefixTests = lib.mapAttrs' (name: value: 
+    if value ? expected then {
+    name = if lib.hasPrefix "test" name then name else "test-${name}";
     inherit value;
+  } else {
+    inherit name;
+    value = prefixTests value;
   });
+
   # Normalize integration tests: some are booleans, some are { expr; expected; }.
   # Wrap booleans as { expr; expected = true; }, pass through existing pairs.
   normalizeTest = value:

--- a/src/api.nix
+++ b/src/api.nix
@@ -22,25 +22,22 @@ rec {
     else x;
 
   # Recursively extract all inline tests from nested mk wrappers.
-  # Returns flat attrset: { "prefix.testName" = { expr; expected; }; ... }
-  extractTests = prefix: x:
+  extractTests = x:
     let
       ownTests =
         if x ? _type && x._type == "nix-effects-api" && x.tests != {}
         then lib.mapAttrs' (name: test: {
-          name = "${prefix}.${name}";
+          name = "test-${name}";
           value = test;
         }) x.tests
         else {};
       childTests =
-        if x ? _type && x._type == "nix-effects-api" && builtins.isAttrs x.value
-        then lib.foldl' (acc: key:
-          acc // extractTests "${prefix}.${key}" x.value.${key}
-        ) {} (builtins.attrNames x.value)
-        else if builtins.isAttrs x && !(x ? _type) && !(x ? _tag)
-        then lib.foldl' (acc: key:
-          acc // extractTests "${prefix}.${key}" x.${key}
-        ) {} (builtins.attrNames x)
+        let
+          isAPI = builtins.isAttrs (x.value or null) && x._type or null == "nix-effects-api";
+          isRaw = builtins.isAttrs x && !(x ? _type) && !(x ? _tag);
+        in
+        if isAPI then lib.mapAttrs (_: extractTests) x.value
+        else if isRaw then lib.mapAttrs (_: extractTests) x
         else {};
     in ownTests // childTests;
 


### PR DESCRIPTION
This allows running only part of the whole tests:

```console

nix-unit --flake .#tests.integration

nix-unit --flake .#tests.inline.tc.elaborate
```