### PR TITLE
fix: Non-flake using locked nixpkgs from unstable channel

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 # Usage:
 #   let fx = import ./. { lib = nixpkgs.lib; };
 #   in fx.run (fx.send "get" null) { get = ...; } initialState
-{ lib, pkgs ? null, ... }:
+{ pkgs ? import ./nixpkgs.nix { }, lib ? pkgs.lib, ... }:
 
 let
   api = import ./src/api.nix { inherit lib; };

--- a/flake.lock
+++ b/flake.lock
@@ -46,18 +46,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
-        "type": "github"
+        "lastModified": 1775710090,
+        "narHash": "sha256-WGjBfvXv/mcg5yBg+AtK1Q3FHyXfjAAeJROmg7DLYfM=",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre977467.4c1018dae018/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A freer-monad effect layer for pure Nix, with a dependent type checker built on top of it";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     nix-unit.url = "github:nix-community/nix-unit";
     nix-unit.inputs = {
       nixpkgs.follows = "nixpkgs";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,8 @@
+# Imports pinned nixpkgs from flake.lock on non-flake environments
+let
+  json = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nixpkgs = with json.nodes.nixpkgs.locked; builtins.fetchTarball {
+    url = url;
+    sha256 = narHash;
+  };
+in import nixpkgs

--- a/tests.nix
+++ b/tests.nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-unit
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs ? import ./nixpkgs.nix { },
   ...
 }:
 let


### PR DESCRIPTION
- Uses official nixpkgs unstable channel instead of git branch.

- Re-uses same nixpkgs between flake and non-flakes for more deterministic tests on both.

- Makes lib arg in default.nix optional.

- default.nix and tests.nix load locked nixpkgs.