### PR TITLE
feat: `bind.*` operators for idiomatic effectful Nix functions.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,8 +60,16 @@ let
   # The public library interface
   fx = {
     # Core ADT
-    inherit (kernel) pure impure send bind map seq pipe kleisli;
+    inherit (kernel) pure impure send map seq pipe kleisli;
     inherit (src.comp) isPure match;
+
+    # Bind combinators
+    bind = {
+      __functor = _: kernel.bind;
+      attrs = src.binds.bindAttrs;
+      comp = src.binds.bindComp;
+      fn = src.binds.bindFn;
+    };
 
     # Queue (advanced — exposed for custom interpreters)
     inherit (kernel) queue;

--- a/src/binds.nix
+++ b/src/binds.nix
@@ -1,0 +1,174 @@
+# nix-effects bind: Idiomatic Nix bind helpers.
+#
+#
+# - bind.attrs: Binds effectful attributeSet values
+# - bind.comp: Binds effectful function args.
+# - bind.fn: Binds pure Nix function args.
+#
+{ fx, api, lib, ... }:
+let
+
+  inherit (fx.comp) pure isComp;
+  inherit (fx.kernel) bind send;
+  inherit (api) mk;
+
+  bindAttrs' = attrs:
+    let
+      skip = n: !builtins.elem n [ "__sort" "__functor" "__functionArgs" ];
+      clean = builtins.filter skip (builtins.attrNames attrs);
+      sort = attrs.__sort or lib.id;
+      names = sort clean;
+      toComp = name:
+        let value = attrs.${name}; in
+        if isComp value
+        then { inherit name value; }
+        else { inherit name; value = send name value; };
+    in
+    builtins.foldl'
+    (prev: curr: bind prev (acc: bind curr.value (result: pure (acc // { ${curr.name} = result; }))))
+    (pure {})
+    (map toComp names);
+
+  bindAttrs = mk {
+    doc = ''
+    Like a bind-chain but operates over named attrset of required-effects.
+
+    ```nix
+    bind.attrs { foo = 99; bar = pure 22; baz = asks (env: env.baz); }
+    ```
+
+    Values that are non-effects become send params: `send "foo" 99`.
+
+    Result has same attr-keys with corresponding effect result.
+
+    See also: `bind.comp`, `bind.fn` for which this is the foundation.
+
+    # NOTE: Ordering of chained effects.
+
+    Since an attrSet has no order, this function chains effects in
+    same order as `builtins.attrNames` (alphabetical). If you need
+    an special order for computations that might be order senstive,
+    specify a `__sort = names => names` function.
+    '';
+    value = bindAttrs';
+    tests = {
+      pure-passes-thru = {
+        expr = (bindAttrs { foo = pure 22; }).value;
+        expected.foo = 22;
+      };
+      impure-passes-thru = {
+        expr = (bindAttrs { foo = (bind (pure 22) (x: pure (x + 1))); }).value;
+        expected.foo = 23;
+      };
+      non-effect-is-send = {
+        expr = let
+          eff = bindAttrs { foo = 22; bar = pure 99; };
+          result = fx.trampoline.run eff {
+            foo = { param, state }: {
+              resume = param * 2;
+              state = state;
+            };
+          } null;
+        in result.value;
+        expected = {
+          foo = 44;
+          bar = 99;
+        };
+      };
+      sorted-send = {
+        expr = let
+          eff = bindAttrs { foo = null; bar = null; __sort = _: [ "bar" "foo" ]; };
+          result = fx.trampoline.run eff {
+            foo = { param, state }: {
+              resume = param;
+              state = state * 2;
+            };
+            bar = { param, state }: {
+              resume = param;
+              state = state + 1;
+            };
+          } 11;
+        in result.state;
+        expected = 24;
+      };
+    };
+  };
+
+  bindComp = mk {
+    doc = ''
+    Turns a Nix effectful function into an effect chain via bindAttrs.
+
+    ```nix
+    bindComp { bar = pure 22; } ({ foo, bar }: pure (foo * bar))
+    ```
+
+    The function sees bar as the result of `pure 22` and `foo` as the
+    result of `send "foo" false` -- false comes directly from using 
+    `lib.functionArgs f`, the handler can know if "foo" is optional in f.
+
+    This works by using `bindAttrs` on the intersection of function args
+    and attrs.
+    '';
+    value = attrs: f:
+      bind (bindAttrs ((lib.functionArgs f) // attrs)) f;
+    tests = {
+      arg-in-attrs = {
+        expr = (bindComp { x = pure 22; } ({ x }: pure (x * 2))).value;
+        expected = 44;
+      };
+      arg-not-in-attrs-is-send = {
+        expr = let
+         eff = bindComp { } ({ foo }: pure (foo * 2));
+         result = fx.trampoline.run eff {
+          foo = { param, state }: {
+            resume = 11;
+            state = state;
+          };
+         } null;
+        in result.value;
+        expected = 22;
+      };
+    };
+  };
+
+  bindFn = mk {
+    doc = ''
+    Like bindComp but works on normal Nix functions and turns
+    its result into a pure-effect.
+
+    ```nix
+    bindFn { bar = pure 22; } ({ foo, bar }: foo * bar)
+    ```
+
+    '';
+    value = attrs: f: 
+      bindComp attrs {
+        __functionArgs = lib.functionArgs f;
+        __functor = _: args: pure (f args);
+      };
+    tests = {
+      arg-in-attrs = {
+        expr = (bindFn { x = pure 22; } ({ x }: x * 2)).value;
+        expected = 44;
+      };
+      arg-not-in-attrs-is-send = {
+        expr = let
+         eff = bindFn { } ({ foo }: foo * 2);
+         result = fx.trampoline.run eff {
+          foo = { param, state }: {
+            resume = 11;
+            state = state;
+          };
+         } null;
+        in result.value;
+        expected = 22;
+      };
+    };
+  };
+
+in mk {
+  doc = "Idiomatic Nix bind helpers";
+  value = {
+    inherit bindAttrs bindComp bindFn;
+  };
+}

--- a/src/comp.nix
+++ b/src/comp.nix
@@ -90,6 +90,25 @@ let
     };
   };
 
+  isComp = mk {
+    doc = "Test whether a value is a computation.";
+    value = comp: (comp._tag or null == "Pure") || (comp._tag or null == "Impure");
+    tests = {
+      "pure-returns-true" = {
+        expr = isComp (pure 1);
+        expected = true;
+      };
+      "impure-returns-true" = {
+        expr = isComp (impure { name = "x"; param = null; } null);
+        expected = true;
+      };
+      "empty-returns-false" = {
+        expr = isComp { };
+        expected = false;
+      };
+    };
+  };
+
   isPure = mk {
     doc = "Test whether a computation is Pure. For hot-path conditionals where match would allocate.";
     value = comp: comp._tag == "Pure";
@@ -107,5 +126,5 @@ let
 
 in mk {
   doc = "Computation ADT: introduction and elimination forms for Pure | Impure.";
-  value = { inherit pure impure match isPure; };
+  value = { inherit pure impure match isPure isComp; };
 }


### PR DESCRIPTION
Adds three new operators

- `bind.attrs`: Monadic bind over effectful attr values. (non effectful values are param for `send attrName attrValue`)

- `bind.comp`: Uses bind.attrs to call an effectful Nix function with the result of several named effects.

- `bind.fn`: Uses bind.comp to call a pure-Nix function and wraps the result of it in pure.

Stacked on #13 