### PR TITLE
feat: effectful handlers — resume with computations 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,7 +67,7 @@ let
     inherit (kernel) queue;
 
     # Interpreter (trampoline)
-    inherit (trampoline) run handle;
+    inherit (trampoline) run handle rotate;
 
     # Handler composition (adapt)
     inherit (adaptMod) adapt adaptHandlers;
@@ -118,6 +118,7 @@ let
       acc = effects.acc;
       choice = effects.choice;
       linear = effects.linear;
+      scope = effects.scope;
     };
 
     # Streams (effectful lazy sequences)

--- a/src/comp.nix
+++ b/src/comp.nix
@@ -90,6 +90,25 @@ let
     };
   };
 
+  isComp = mk {
+    doc = "Test whether a value is a computation.";
+    value = comp: (comp._tag or null == "Pure") || (comp._tag or null == "Impure");
+    tests = {
+      "pure-returns-true" = {
+        expr = isComp (pure 1);
+        expected = true;
+      };
+      "impure-returns-true" = {
+        expr = isComp (impure { name = "x"; param = null; } null);
+        expected = true;
+      };
+      "empty-returns-false" = {
+        expr = isComp { };
+        expected = false;
+      };
+    };
+  };
+
   isPure = mk {
     doc = "Test whether a computation is Pure. For hot-path conditionals where match would allocate.";
     value = comp: comp._tag == "Pure";
@@ -107,5 +126,5 @@ let
 
 in mk {
   doc = "Computation ADT: introduction and elimination forms for Pure | Impure.";
-  value = { inherit pure impure match isPure; };
+  value = { inherit pure impure match isPure isComp; };
 }

--- a/src/effects/scope.nix
+++ b/src/effects/scope.nix
@@ -1,0 +1,159 @@
+# nix-effects scope: Computation-scoped handlers via effect rotation
+#
+# Provides computation-scoped handler installation without polluting
+# user-visible state. Built on fx.rotate (Kyo-style handler rotation).
+#
+#
+# scope.stateful - Install handlers for subcomputation, preserving state around rotation.
+# scope.run    — run body with scoped handlers, hide scope state
+# scope.runWith — run body with scoped handlers, expose scope state
+# scope.handlersFromAttrs - helper for creating handlers from Nix attrsets
+{ fx, api, lib, ... }:
+
+let
+  inherit (api) mk;
+  inherit (fx.kernel) pure bind send;
+  inherit (fx.trampoline) rotate handle;
+  inherit (fx.effects) state;
+
+  isHandler = f: lib.isFunction f && (lib.intersectAttrs { state = 1; param = 1; } (lib.functionArgs f)) != { };
+
+  handlersFromAttrs = mk {
+    doc = ''
+    Helper to transform an attrset into named handlers.
+
+    If attrValue is a function `{ param, state }` it is used directly as handler;
+    If attrValue is a function, resume is `f param` and preserves state;
+    Otherwise a constant handler always resumes with attrValue, preserving state.
+    '';
+    value = 
+      lib.mapAttrs (name: value: 
+      if isHandler value then value
+      else if lib.isFunction value then { param, state }: { inherit state; resume = value param; }
+      else { state, ... }: { inherit state; resume = value; });
+    tests = {
+      "preserves-handlers" = {
+        expr = (handlersFromAttrs { foo = { param, state }: 22; }).foo { param = 1; state = 2; };
+        expected = 22;
+      };
+      "constant" = {
+        expr = (handlersFromAttrs { foo = 22; }).foo { param = 1; state = 2; };
+        expected.resume = 22;
+        expected.state = 2;
+      };
+      "function" = {
+        expr = (handlersFromAttrs { foo = n: n * 2; }).foo { param = 11; state = 2; };
+        expected.resume = 22;
+        expected.state = 2;
+      };
+    };
+  };
+
+
+  stateful = mk {
+    doc = ''
+    Run a computation with scoped handlers while preserving
+    state around effect rotation.
+
+    ```
+    scope : handlers -> Computation a -> Computation a
+    ```
+    '';
+
+    value = handlers: body:
+      state.update (state: rotate { inherit handlers state; } body);
+
+    tests = {
+      "preserves-state-around" = {
+        expr = handle {
+            handlers = state.handler;
+            state = 11;
+          } (stateful {
+            foo = { param, state }: {
+              state = state * 2;
+              resume = state * 3;
+            };
+         } (send "foo" null));
+        expected.state = 22;
+        expected.value = 33;
+      };
+    };
+  };
+
+  run = mk {
+    doc = ''
+      Run a computation with scoped handlers. Effects matching `handlers`
+      are handled inside the scope. Unknown effects rotate outward.
+      The scope's internal state is hidden — caller sees only the body's value.
+
+      ```
+      scope.run : { handlers, state? } -> Computation a -> Computation a
+      ```
+    '';
+    value = {
+      handlers,
+      state ? null,
+    }:
+      rotate {
+        inherit handlers state;
+        return = value: _state: value;
+      };
+    tests = {
+      "scoped-handler-returns-value" = {
+        expr =
+          let
+            comp = send "x" null;
+            scoped = run {
+              handlers.x = { state, ... }: { resume = 42; inherit state; };
+            } comp;
+            result = handle { handlers = {}; } scoped;
+          in result.value;
+        expected = 42;
+      };
+      "scope-hides-internal-state" = {
+        expr =
+          let
+            comp = bind (send "inc" 1) (_: send "inc" 1);
+            scoped = run {
+              handlers.inc = { param, state }: { resume = null; state = state + param; };
+              state = 0;
+            } comp;
+            result = handle { handlers = {}; } scoped;
+          in result.value;
+        expected = null;
+      };
+    };
+  };
+
+  runWith = mk {
+    doc = ''
+      Like scope.run but exposes the scope's final state alongside the value.
+
+      ```
+      scope.runWith : { handlers, state? } -> Computation a -> Computation { value, state }
+      ```
+    '';
+    value = rotate;
+    tests = {
+      "runWith-exposes-state" = {
+        expr =
+          let
+            comp = bind (send "inc" 1) (_: send "inc" 1);
+            scoped = runWith {
+              handlers.inc = { param, state }: { resume = null; state = state + param; };
+              state = 0;
+            } comp;
+            result = handle { handlers = {}; } scoped;
+          in result.value.state;
+        expected = 2;
+      };
+    };
+  };
+
+
+in mk {
+  doc = "Computation-scoped handlers via effect rotation.";
+  value = { 
+    inherit stateful run runWith handlersFromAttrs; 
+  };
+}

--- a/src/effects/state.nix
+++ b/src/effects/state.nix
@@ -59,6 +59,36 @@ let
     };
   };
 
+
+  update = mk {
+    doc = ''
+      Apply a computation to the current state. Returns a Computation that,
+      when handled, updates the state and returns value.
+
+      ```
+      update : (s -> Computation { state, value }) -> Computation value
+      ```
+    '';
+    value = f:
+      bind get.value (state: bind (f state) ({ state, value }: bind (put.value state) (_: pure value)));
+    tests = {
+      "update-is-impure" = {
+        expr = fx.comp.isPure (update (x: pure {
+          value = x + 1;
+          state = 99;
+        }));
+        expected = false;
+      };
+      "update-reads-and-updates" = {
+        expr = 
+          fx.trampoline.handle { handlers = handler.value; state = 11; } 
+            (update (s: pure { state = s * 2; value = s * 3; }));
+        expected.state = 22;
+        expected.value = 33;
+      };
+    };
+  };
+
   modify = mk {
     doc = ''
       Apply a function to the current state. Returns a Computation that,
@@ -131,6 +161,6 @@ let
 in mk {
   doc = "Mutable state effect: get/put/modify with standard handler.";
   value = {
-    inherit get put modify gets handler;
+    inherit get put modify update gets handler;
   };
 }

--- a/src/trampoline.nix
+++ b/src/trampoline.nix
@@ -24,7 +24,7 @@
 
 let
   queue = fx.queue;
-  inherit (fx.comp) pure impure isPure;
+  inherit (fx.comp) pure impure isPure isComp;
   inherit (api) mk;
 
   # -- Queue application --
@@ -73,6 +73,10 @@ let
 
   # -- Interpreter --
 
+  resumeWithQueue = q: value:
+    if q._variant == "Identity" then pure value
+    else applyQueue q value 0;
+
   interpret = { comp, handlers, initialState }:
     let
       steps = builtins.genericClosure {
@@ -101,17 +105,95 @@ let
               if result ? abort then
                 [{ key = k; _comp = pure result.abort; _state = newState; }]
               else if result ? resume then
-                let
-                  q = step._comp.queue;
-                  nextComp =
-                    if q._variant == "Identity" then pure result.resume
-                    else applyQueue q result.resume 0;
-                in [{ key = k; _comp = nextComp; _state = newState; }]
+                [{ key = k;
+                   _comp = resumeWithQueue step._comp.queue result.resume;
+                   _state = newState; }]
               else
                 throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }";
       };
       final = lib.last steps;
     in { value = final._comp.value; state = final._state; };
+
+  # -- Selective interpreter (handler rotation) --
+
+  effectRotateSlow = { comp, handlers, state, done }:
+    let
+      steps = builtins.genericClosure {
+        startSet = [{ key = 0; _comp = comp; _state = state; }];
+        operator = step:
+          if isPure step._comp then []
+          else
+            let eff = step._comp.effect; in
+            if handlers ? ${eff.name} then
+              let
+                result = handlers.${eff.name} {
+                  param = eff.param;
+                  state = step._state;
+                };
+                newState = if result ? state then result.state
+                  else throw "nix-effects: handler for '${eff.name}' must include 'state' in return value";
+                k = builtins.deepSeq newState (step.key + 1);
+              in
+                if result ? abort then
+                  [{ key = k; _comp = pure (done result.abort newState); _state = newState; }]
+                else if result ? resume then
+                  [{ key = k;
+                     _comp = resumeWithQueue step._comp.queue result.resume;
+                     _state = newState; }]
+                else
+                  throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }"
+            else [];
+      };
+      last = lib.last steps;
+    in
+      if isPure last._comp then pure (done last._comp.value last._state)
+      else
+        impure last._comp.effect (queue.singleton (value:
+          effectRotate {
+            comp = resumeWithQueue last._comp.queue value;
+            handlers = handlers;
+            state = last._state;
+            inherit done;
+          } 0));
+
+  effectRotate = { comp, handlers, state, done }: depth:
+    if isPure comp then pure (done comp.value state)
+    else
+      let
+        eff = comp.effect;
+      in
+      if handlers ? ${eff.name} then
+        let
+          result = handlers.${eff.name} {
+            param = eff.param;
+            inherit state;
+          };
+          newState = if result ? state then result.state
+            else throw "nix-effects: handler for '${eff.name}' must include 'state' in return value";
+        in
+          if result ? abort then
+            pure (done result.abort newState)
+          else if result ? resume then
+            if depth >= 500 then
+              effectRotateSlow {
+                comp = resumeWithQueue comp.queue result.resume;
+                inherit handlers done;
+                state = newState;
+              }
+            else
+              effectRotate {
+                comp = resumeWithQueue comp.queue result.resume;
+                inherit handlers done;
+                state = newState;
+              } (depth + 1)
+          else
+            throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }"
+      else
+        impure eff (queue.singleton (value:
+          effectRotate {
+            comp = resumeWithQueue comp.queue value;
+            inherit handlers state done;
+          } 0));
 
   run = mk {
     doc = ''
@@ -140,7 +222,7 @@ let
       Time: O(n) where n = number of effects in the computation.
     '';
     value = comp: handlers: initialState:
-      assert (builtins.isAttrs comp && comp ? _tag)
+      assert (isComp comp)
         || throw "nix-effects: run expects a computation (Pure or Impure), got ${builtins.typeOf comp}";
       interpret { inherit comp handlers initialState; };
   };
@@ -168,7 +250,7 @@ let
       handlers,
       state ? null,
     }: comp:
-      assert (builtins.isAttrs comp && comp ? _tag)
+      assert (isComp comp)
         || throw "nix-effects: handle expects a computation (Pure or Impure), got ${builtins.typeOf comp}";
       let r = interpret { inherit comp handlers; initialState = state; };
       in return r.value r.state;
@@ -217,9 +299,90 @@ let
     };
   };
 
+  rotate = mk {
+    doc = ''
+      Selectively handle known effects and rotate unknown effects outward.
+
+      ```
+      rotate : { return?, handlers, state? } -> Computation a -> Computation b
+      ```
+
+      If the current effect has a matching handler, the handler is applied.
+      If it does not match, the effect is re-suspended and its continuation
+      is wrapped so handling resumes after that effect is interpreted by an
+      outer handler.
+
+      This corresponds to the Kyo-style handler rotation law
+      from https://gist.github.com/vic/3a7f52974a28675dbaf40b34bec74787:
+
+      ```
+      handle(tag1, suspend(tag2, i, k), f) = suspend(tag2, i, x => handle(tag1, k(x), f))` for `tag1 != tag2
+      ```
+    '';
+    value = {
+      return ? (value: state: { inherit value state; }),
+      handlers,
+      state ? null,
+    }: comp:
+      assert (isComp comp)
+        || throw "nix-effects: rotate expects a computation (Pure or Impure), got ${builtins.typeOf comp}";
+      effectRotate {
+        inherit comp handlers state;
+        done = return;
+      } 0;
+    tests = {
+      "rotate-matches-handled-effect" = {
+        expr =
+          let
+            comp = fx.kernel.send "inc" 1;
+            rotated = rotate {
+              handlers = {
+                inc = { param, state }: { resume = null; state = state + param; };
+              };
+              state = 0;
+            } comp;
+            result = handle { handlers = {}; } rotated;
+          in result.value.state;
+        expected = 1;
+      };
+      "rotate-preserves-unhandled-effect" = {
+        expr =
+          let
+            comp = fx.kernel.send "outer" 7;
+            rotated = rotate {
+              handlers = {
+                inc = { param, state }: { resume = null; state = state + param; };
+              };
+              state = 0;
+            } comp;
+          in rotated.effect.name;
+        expected = "outer";
+      };
+      "rotate-handles-after-outer-resume" = {
+        expr =
+          let
+            comp = fx.kernel.bind (fx.kernel.send "outer" 7) (_:
+              fx.kernel.send "inc" 1);
+            rotated = rotate {
+              handlers = {
+                inc = { param, state }: { resume = null; state = state + param; };
+              };
+              state = 0;
+            } comp;
+            result = handle {
+              handlers = {
+                outer = { param, state }: { resume = param * 2; inherit state; };
+              };
+            } rotated;
+          in result.value.state;
+        expected = 1;
+      };
+    };
+  };
+
 in mk {
   doc = "Trampolined interpreter using builtins.genericClosure for O(1) stack depth.";
   value = {
-    inherit run handle;
+    inherit run handle rotate;
   };
 }

--- a/src/trampoline.nix
+++ b/src/trampoline.nix
@@ -77,6 +77,22 @@ let
     if q._variant == "Identity" then pure value
     else applyQueue q value 0;
 
+  # Resume with a value or computation. If the resume is a computation,
+  # splice its effects before the continuation queue. This enables
+  # effectful handlers: handlers that return computations to be handled
+  # before the continuation runs.
+  resumeCompOrValue = q: r:
+    if isComp r then
+      if isPure r then
+        resumeWithQueue q r.value
+      else
+        # Impure: append original continuation queue to computation's queue.
+        # The computation's effects run first; when it reaches Pure,
+        # the original continuation picks up the result.
+        impure r.effect (queue.append r.queue q)
+    else
+      resumeWithQueue q r;
+
   interpret = { comp, handlers, initialState }:
     let
       steps = builtins.genericClosure {
@@ -106,7 +122,7 @@ let
                 [{ key = k; _comp = pure result.abort; _state = newState; }]
               else if result ? resume then
                 [{ key = k;
-                   _comp = resumeWithQueue step._comp.queue result.resume;
+                   _comp = resumeCompOrValue step._comp.queue result.resume;
                    _state = newState; }]
               else
                 throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }";
@@ -176,13 +192,13 @@ let
           else if result ? resume then
             if depth >= 500 then
               effectRotateSlow {
-                comp = resumeWithQueue comp.queue result.resume;
+                comp = resumeCompOrValue comp.queue result.resume;
                 inherit handlers done;
                 state = newState;
               }
             else
               effectRotate {
-                comp = resumeWithQueue comp.queue result.resume;
+                comp = resumeCompOrValue comp.queue result.resume;
                 inherit handlers done;
                 state = newState;
               } (depth + 1)
@@ -296,6 +312,80 @@ let
           in result.value;
         expected = { error = "boom"; };
       };
+      "effectful-resume-runs-sub-computation" = {
+        expr =
+          let
+            send' = fx.kernel.send;
+            bind' = fx.kernel.bind;
+            comp = send' "outer" null;
+            result = handle {
+              handlers = {
+                "outer" = { param, state }: {
+                  resume = bind' (send' "inner" 10) (x: pure (x * 2));
+                  inherit state;
+                };
+                "inner" = { param, state }: {
+                  resume = param + 1;
+                  inherit state;
+                };
+              };
+            } comp;
+          in result.value;
+        expected = 22;
+      };
+      "effectful-resume-threads-state" = {
+        expr =
+          let
+            send' = fx.kernel.send;
+            bind' = fx.kernel.bind;
+            comp = send' "resolve" null;
+            result = handle {
+              handlers = {
+                "resolve" = { param, state }: {
+                  resume = bind' (send' "count" null) (_: send' "count" null);
+                  state = state // { resolved = true; };
+                };
+                "count" = { param, state }: {
+                  resume = null;
+                  state = state // { n = (state.n or 0) + 1; };
+                };
+              };
+              state = {};
+            } comp;
+          in { n = result.state.n; resolved = result.state.resolved; };
+        expected = { n = 2; resolved = true; };
+      };
+      "effectful-resume-with-continuation" = {
+        expr =
+          let
+            send' = fx.kernel.send;
+            bind' = fx.kernel.bind;
+            comp = bind' (send' "fetch" null) (x: pure (x + 100));
+            result = handle {
+              handlers = {
+                "fetch" = { param, state }: {
+                  resume = bind' (send' "db" null) (row: pure row.value);
+                  inherit state;
+                };
+                "db" = { param, state }: {
+                  resume = { value = 42; };
+                  inherit state;
+                };
+              };
+            } comp;
+          in result.value;
+        expected = 142;
+      };
+      "plain-resume-unchanged" = {
+        expr =
+          let
+            comp = fx.kernel.send "x" 5;
+            result = handle {
+              handlers.x = { param, state }: { resume = param + 1; inherit state; };
+            } comp;
+          in result.value;
+        expected = 6;
+      };
     };
   };
 
@@ -376,6 +466,28 @@ let
             } rotated;
           in result.value.state;
         expected = 1;
+      };
+      "effectful-resume-in-rotate" = {
+        expr =
+          let
+            send' = fx.kernel.send;
+            bind' = fx.kernel.bind;
+            comp = send' "a" null;
+            rotated = rotate {
+              handlers = {
+                "a" = { param, state }: {
+                  resume = bind' (send' "b" 5) (x: pure (x + 1));
+                  inherit state;
+                };
+                "b" = { param, state }: {
+                  resume = param * 2;
+                  inherit state;
+                };
+              };
+            } comp;
+            result = handle { handlers = {}; } rotated;
+          in result.value.value;
+        expected = 11;
       };
     };
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -17,6 +17,7 @@ let
   verifiedFunctionTests = import ../examples/verified-functions.nix { inherit lib fx; };
   docsTests = import ./docs-test.nix { inherit lib fx; };
   pipelineTests = import ./pipeline-test.nix { inherit lib fx; };
+  scopeTests = import ./scope-test.nix { inherit lib fx; };
 
 in {
   inherit (trampolineTests) pureComputation singleEffect simpleCounter
@@ -25,7 +26,11 @@ in {
           statefulAccumulation earlyPure pureBindChain
           handleWithReturn adaptState adaptHandlersTest
           leftNestedBind
-          qAppPureChain viewlGoLeftNested;
+          qAppPureChain viewlGoLeftNested
+          effectRotationResumesInner
+          effectRotationSuspendsUnknown
+          effectRotationStackSafety
+          effectRotationNestedHandlers;
 
   inherit (typesTests) validPortTest vectorTest universeTest
           recordRefinementTest maybeTest depRecordTest
@@ -98,6 +103,11 @@ in {
           chooseFirstTest choiceFailTest
           choiceGuardTrueTest choiceGuardFalseTest choicePendingTest
           readerWriterComposedTest;
+
+  inherit (scopeTests) twoUsersTest scopeStateIsolation scopeEscapeEffects nestedScopes
+          scopeWithStatefulHandler scopeDoesNotCorruptUserState
+          dynamicHandlerFromEffect abortInsideScope threeUsersFanOut
+          scopeOverrideInNested;
 
   inherit (streamTests) fromListToListTest fromListEmptyTest
           rangeTest rangeEmptyTest replicateTest replicateZeroTest
@@ -172,5 +182,6 @@ in {
             && equalityProofTests.allPass
             && verifiedFunctionTests.allPass
             && docsTests.allPass
-            && pipelineTests.allPass;
+            && pipelineTests.allPass
+            && scopeTests.allPass;
 }

--- a/tests/scope-test.nix
+++ b/tests/scope-test.nix
@@ -1,0 +1,187 @@
+# nix-effects scopconst integration tests
+#
+# Validates computation-scoped handlers via effect rotation:
+# - Host/users example: different paths get different handler bindings
+# - State isolation: scope state does not leak to outer state
+# - Escape effects: unhandled effects rotate to outer handler
+# - Nesting: scopes compose correctly
+{ lib, fx }:
+
+let
+  inherit (fx) pure bind send handle;
+  scope = fx.effects.scope;
+
+  getUser = send "user" null;
+  getHost = send "host" null;
+
+  greet = bind getUser (user:
+    bind getHost (host:
+      pure "${user}@${host}"));
+
+  hostHandler = {
+    host = { state, ... }: { resume = "myhost"; inherit state; };
+  };
+
+  constScope = name: value:
+    scope.run {
+      handlers.${name} = { param, state }: { inherit state; resume = value; };
+    };
+
+  twoUsersTest = {
+    expr =
+      let
+        comp =
+          bind (constScope "user" "alice" greet) (a:
+          bind (constScope "user" "bob"   greet) (b:
+            pure { alice = a; bob = b; }));
+        result = handle { handlers = hostHandler; } comp;
+      in result.value;
+    expected = { alice = "alice@myhost"; bob = "bob@myhost"; };
+  };
+
+  scopeStateIsolation = {
+    expr =
+      let
+        incComp = bind (send "inc" 1) (_: send "inc" 1);
+        scoped = scope.runWith {
+          handlers.inc = { param, state }: { resume = null; state = state + param; };
+          state = 0;
+        } incComp;
+        result = handle { state = "outer-untouched"; handlers = {}; } scoped;
+      in { innerState = result.value.state; outerState = result.state; };
+    expected = { innerState = 2; outerState = "outer-untouched"; };
+  };
+
+  scopeEscapeEffects = {
+    expr =
+      let
+        comp = bind getUser (user:
+          bind (send "log" user) (_:
+            pure user));
+        scoped = constScope "user" "alice" comp;
+        result = handle {
+          handlers.log = { param, state }: { resume = null; state = state ++ [param]; };
+          state = [];
+        } scoped;
+      in { value = result.value; logs = result.state; };
+    expected = { value = "alice"; logs = [ "alice" ]; };
+  };
+
+  nestedScopes = {
+    expr =
+      let
+        comp = bind (send "env" null) (env:
+          bind (send "user" null) (user:
+            pure "${env}/${user}"));
+        inner = constScope "user" "bob" comp;
+        outer = constScope "env" "prod" inner;
+        result = handle { handlers = {}; } outer;
+      in result.value;
+    expected = "prod/bob";
+  };
+
+  scopeWithStatefulHandler = {
+    expr =
+      let
+        visitComp = bind (send "visit" null) (_: send "visit" null);
+        aliceScope = scope.runWith {
+          handlers.visit = { state, ... }: { resume = null; state = state + 1; };
+          state = 0;
+        } visitComp;
+        bobScope = scope.runWith {
+          handlers.visit = { state, ... }: { resume = null; state = state + 1; };
+          state = 0;
+        } visitComp;
+        comp = bind aliceScope (a: bind bobScope (b:
+          pure { aliceVisits = a.state; bobVisits = b.state; }));
+        result = handle { handlers = {}; } comp;
+      in result.value;
+    expected = { aliceVisits = 2; bobVisits = 2; };
+  };
+
+  scopeDoesNotCorruptUserState = {
+    expr =
+      let
+        comp =
+          bind (send "inc" 1) (_:
+          bind (constScope "user" "alice" (
+            bind (send "inc" 1) (_: getUser)
+          )) (user:
+          bind (send "inc" 1) (_:
+            pure user)));
+        result = handle {
+          handlers.inc = { param, state }: { resume = null; state = state + param; };
+          state = 0;
+        } comp;
+      in { value = result.value; outerState = result.state; };
+    expected = { value = "alice"; outerState = 3; };
+  };
+
+  dynamicHandlerFromEffect = {
+    expr =
+      let
+        comp =
+          bind (send "getHandler" null) (userName:
+            constScope "user" userName getUser);
+        result = handle {
+          handlers.getHandler = { state, ... }: { resume = "dynamic-user"; inherit state; };
+        } comp;
+      in result.value;
+    expected = "dynamic-user";
+  };
+
+  abortInsideScope = {
+    expr =
+      let
+        comp = bind (send "fail" "boom") (_: pure "unreachable");
+        scoped = scope.run {
+          handlers.fail = { param, state }: { abort = { error = param; }; inherit state; };
+        } comp;
+        outer = bind scoped (v: pure { got = v; });
+        result = handle { handlers = {}; } outer;
+      in result.value;
+    expected = { got = { error = "boom"; }; };
+  };
+
+  threeUsersFanOut = {
+    expr =
+      let
+        users = [ "alice" "bob" "carol" ];
+        perUser = builtins.map (u: constScope "user" u greet) users;
+        comp = builtins.foldl' (acc: sc:
+          bind acc (results: bind sc (v: pure (results ++ [v])))
+        ) (pure []) perUser;
+        result = handle { handlers = hostHandler; } comp;
+      in result.value;
+    expected = [ "alice@myhost" "bob@myhost" "carol@myhost" ];
+  };
+
+  scopeOverrideInNested = {
+    expr =
+      let
+        comp = bind getUser (u1:
+          bind (constScope "user" "inner" getUser) (u2:
+            pure { outer = u1; inner = u2; }));
+        scoped = constScope "user" "outer" comp;
+        result = handle { handlers = {}; } scoped;
+      in result.value;
+    expected = { outer = "outer"; inner = "inner"; };
+  };
+
+  allPass = twoUsersTest.expr == twoUsersTest.expected
+    && scopeStateIsolation.expr == scopeStateIsolation.expected
+    && scopeEscapeEffects.expr == scopeEscapeEffects.expected
+    && nestedScopes.expr == nestedScopes.expected
+    && scopeWithStatefulHandler.expr == scopeWithStatefulHandler.expected
+    && scopeDoesNotCorruptUserState.expr == scopeDoesNotCorruptUserState.expected
+    && dynamicHandlerFromEffect.expr == dynamicHandlerFromEffect.expected
+    && abortInsideScope.expr == abortInsideScope.expected
+    && threeUsersFanOut.expr == threeUsersFanOut.expected
+    && scopeOverrideInNested.expr == scopeOverrideInNested.expected;
+
+in {
+  inherit twoUsersTest scopeStateIsolation scopeEscapeEffects nestedScopes
+          scopeWithStatefulHandler scopeDoesNotCorruptUserState
+          dynamicHandlerFromEffect abortInsideScope threeUsersFanOut
+          scopeOverrideInNested allPass;
+}

--- a/tests/trampoline-test.nix
+++ b/tests/trampoline-test.nix
@@ -227,6 +227,87 @@ let
       } 0;
     in result.state == 1001;
 
+  # -- Test 17: selective handler rotation (Kyo-style) --
+  # Unhandled effects are rotated outward and resumed by outer handlers.
+  effectRotationResumesInner =
+    let
+      comp =
+        bind (send "outer" 3) (x:
+        bind (send "inc" x) (_:
+        pure "ok"));
+
+      rotated = fx.rotate {
+        handlers = {
+          inc = { param, state }: { resume = null; state = state + param; };
+        };
+        state = 0;
+      } comp;
+
+      result = handle {
+        handlers = {
+          outer = { param, state }: { resume = param * 2; inherit state; };
+        };
+      } rotated;
+    in result.value == { value = "ok"; state = 6; };
+
+  # -- Test 18: rotation leaves unknown effect suspended --
+  effectRotationSuspendsUnknown =
+    let
+      comp = send "unknown" 1;
+      rotated = fx.rotate {
+        handlers = {
+          inc = { param, state }: { resume = null; state = state + param; };
+        };
+        state = 0;
+      } comp;
+    in (!fx.isPure rotated) && rotated.effect.name == "unknown";
+
+  # -- Test: rotation stack safety — 10,000 handled effects --
+  # rotateInterpret recursively calls itself for each handled effect.
+  # Without trampolining, this blows the stack.
+  effectRotationStackSafety =
+    let
+      comp = buildChain "inc" 1 10000;
+      rotated = fx.rotate {
+        handlers = {
+          inc = { param, state }: { resume = null; state = state + param; };
+        };
+        state = 0;
+      } comp;
+      result = handle { handlers = {}; } rotated;
+    in result.value.state == 10000;
+
+  # -- Test 19: rotation supports nested selective handlers --
+  effectRotationNestedHandlers =
+    let
+      comp =
+        bind (send "outer" 5) (v:
+        bind (send "inner" v) (_:
+        pure "done"));
+
+      innerRotated = fx.rotate {
+        handlers = {
+          inner = { param, state }: { resume = null; state = state + param; };
+        };
+        state = 0;
+      } comp;
+
+      outerRotated = fx.rotate {
+        handlers = {
+          outer = { param, state }: { resume = param + 1; inherit state; };
+        };
+        state = null;
+      } innerRotated;
+
+      result = handle { handlers = {}; } outerRotated;
+    in result.value == {
+      value = {
+        value = "done";
+        state = 6;
+      };
+      state = null;
+    };
+
 in {
   inherit pureComputation singleEffect simpleCounter
           tenThousandOps hundredThousandOps
@@ -234,7 +315,11 @@ in {
           statefulAccumulation earlyPure pureBindChain
           handleWithReturn adaptState adaptHandlersTest
           leftNestedBind
-          qAppPureChain viewlGoLeftNested;
+          qAppPureChain viewlGoLeftNested
+          effectRotationResumesInner
+          effectRotationSuspendsUnknown
+          effectRotationStackSafety
+          effectRotationNestedHandlers;
 
   allPass = pureComputation && singleEffect && simpleCounter
             && tenThousandOps && hundredThousandOps
@@ -242,5 +327,9 @@ in {
             && statefulAccumulation && earlyPure && pureBindChain
             && handleWithReturn && adaptState && adaptHandlersTest
             && leftNestedBind
-            && qAppPureChain && viewlGoLeftNested;
+            && qAppPureChain && viewlGoLeftNested
+            && effectRotationResumesInner
+            && effectRotationSuspendsUnknown
+            && effectRotationStackSafety
+            && effectRotationNestedHandlers;
 }


### PR DESCRIPTION
Handlers can now return computations as their resume value.
When resume is a computation (Pure or Impure), it gets handled
first by the same handler set, then its result feeds the
continuation. Plain value resumes work unchanged.

This enables deep/recursive handling patterns where a handler
needs to run a sub-computation before resuming.

Co-authored-by: @sini

Stacked on #8, #13 