### PR TITLE
feat: hasHandler to query if handler is in scope.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -181,6 +181,7 @@ let
       choice = effects.choice;
       linear = effects.linear;
       scope = effects.scope;
+      hasHandler = effects.hasHandler;
     };
 
     # Streams (effectful lazy sequences)

--- a/src/effects/hasHandler.nix
+++ b/src/effects/hasHandler.nix
@@ -1,0 +1,76 @@
+# nix-effects hasHandler: runtime handler existence check
+#
+# Send "has-handler" query to check if a handler exists in current scope.
+{ fx, api, lib, ... }:
+
+let
+  inherit (api) mk;
+  inherit (fx.kernel) send;
+  inherit (fx.kernel) bind pure;
+  inherit (fx.trampoline) handle;
+
+  hasHandler = mk {
+    doc = ''
+      Check if a handler with given name exists in current scope.
+
+      ```
+      hasHandler : String -> Computation Bool
+      ```
+    '';
+    value = send "has-handler";
+    tests = {
+      "hasHandler-is-impure" = {
+        expr = (fx.comp.isPure (hasHandler "foo"));
+        expected = false;
+      };
+      "hasHandler-finds-root-handler" = {
+        expr =
+          let
+            comp = hasHandler "myEffect";
+            result = handle {
+              handlers.myEffect = { state, ... }: { resume = 42; inherit state; };
+              state = null;
+            } comp;
+          in result.value;
+        expected = true;
+      };
+      "hasHandler-missing-handler-returns-false" = {
+        expr =
+          let
+            comp = hasHandler "missing";
+            result = handle {
+              handlers.myEffect = { state, ... }: { resume = 42; inherit state; };
+              state = null;
+            } comp;
+          in result.value;
+        expected = false;
+      };
+      "hasHandler-nested-scope" = {
+        expr =
+          let
+            scope = fx.effects.scope;
+            scoped = scope.run {
+              handlers.inner = { state, ... }: { resume = null; inherit state; };
+            } (hasHandler "inner");
+            result = handle { handlers = {}; } scoped;
+          in result.value;
+        expected = true;
+      };
+      "hasHandler-escapes-scope" = {
+        expr =
+          let
+            scope = fx.effects.scope;
+            comp = hasHandler "outer";
+            scoped = scope.run {
+              handlers.inner = { state, ... }: { resume = null; inherit state; };
+            } comp;
+            result = handle {
+              handlers.outer = { state, ... }: { resume = null; inherit state; };
+            } scoped;
+          in result.value;
+        expected = true;
+      };
+    };
+  };
+
+in hasHandler

--- a/src/trampoline.nix
+++ b/src/trampoline.nix
@@ -106,12 +106,17 @@ let
           else
             let
               eff = step._comp.effect;
-              handler = handlers.${eff.name} or
-                (throw "nix-effects: unhandled effect '${eff.name}'");
-              result = handler {
-                param = eff.param;
-                state = step._state;
-              };
+              handler = localHandler handlers eff;
+              result = 
+                if handler == null 
+                then 
+                  if eff.name == "has-handler"
+                  then { resume = false; state = step._state; }
+                  else throw "nix-effects: unhandled effect '${eff.name}'"
+                else handler {
+                  param = eff.param;
+                  state = step._state;
+                };
               newState = if result ? state then result.state
                 else throw "nix-effects: handler for '${eff.name}' must include 'state' in return value";
               # deepSeq newState in key: genericClosure forces key for dedup,
@@ -132,6 +137,14 @@ let
 
   # -- Selective interpreter (handler rotation) --
 
+  localHandler = handlers: eff:
+    if eff.name == "has-handler" then
+      if handlers ? ${eff.param}
+      then { param, state }: { inherit state; resume = true; }
+      else null # causes has-handler to rotate up
+    else
+      handlers.${eff.name} or null;
+
   effectRotateSlow = { comp, handlers, state, done }:
     let
       steps = builtins.genericClosure {
@@ -139,10 +152,12 @@ let
         operator = step:
           if isPure step._comp then []
           else
-            let eff = step._comp.effect; in
-            if handlers ? ${eff.name} then
+            let
+              eff = step._comp.effect;
+              handler = localHandler handlers eff;
+            in if handler != null then
               let
-                result = handlers.${eff.name} {
+                result = handler {
                   param = eff.param;
                   state = step._state;
                 };
@@ -177,10 +192,10 @@ let
     else
       let
         eff = comp.effect;
-      in
-      if handlers ? ${eff.name} then
+        handler = localHandler handlers eff;
+      in if handler != null then
         let
-          result = handlers.${eff.name} {
+          result = handler {
             param = eff.param;
             inherit state;
           };


### PR DESCRIPTION
This patch adds `fx.effects.hasHandler`, dispatched internally by trampoline having access to local handlers.

If handler is not found at current scope it propagates up until root via normal effect rotation.

When handler is not found at root returns false.