### PR TITLE
feat: deep handler semantics for effect rotation

### DIFF
--- a/src/trampoline.nix
+++ b/src/trampoline.nix
@@ -121,9 +121,18 @@ let
               if result ? abort then
                 [{ key = k; _comp = pure result.abort; _state = newState; }]
               else if result ? resume then
-                [{ key = k;
-                   _comp = resumeCompOrValue step._comp.queue result.resume;
-                   _state = newState; }]
+                let
+                  # Deep handler semantics: rotated effects tag their
+                  # continuation queue with __rawResume. For those, pass
+                  # the resume as-is so the rotation continuation can
+                  # route effectful resumes through inner scope handlers.
+                  resume =
+                    if step._comp.queue.__rawResume or false then
+                      resumeWithQueue step._comp.queue result.resume
+                    else
+                      resumeCompOrValue step._comp.queue result.resume;
+                in
+                [{ key = k; _comp = resume; _state = newState; }]
               else
                 throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }";
       };
@@ -164,13 +173,13 @@ let
     in
       if isPure last._comp then pure (done last._comp.value last._state)
       else
-        impure last._comp.effect (queue.singleton (value:
+        impure last._comp.effect ((queue.singleton (outerResume:
           effectRotate {
-            comp = resumeWithQueue last._comp.queue value;
+            comp = resumeCompOrValue last._comp.queue outerResume;
             handlers = handlers;
             state = last._state;
             inherit done;
-          } 0));
+          } 0)) // { __rawResume = true; });
 
   effectRotate = { comp, handlers, state, done }: depth:
     if isPure comp then pure (done comp.value state)
@@ -205,11 +214,17 @@ let
           else
             throw "nix-effects: handler for '${eff.name}' must return { resume; state; } or { abort; state; }"
       else
-        impure eff (queue.singleton (value:
+        # Effect not in scoped handlers — rotate outward.
+        # Deep handler semantics: the continuation routes the outer handler's
+        # resume back through effectRotate. If the resume is a computation
+        # (effectful handler), its effects pass through the inner handlers
+        # first. This matches Koka/Eff behavior where continuations capture
+        # the full handler stack.
+        impure eff ((queue.singleton (outerResume:
           effectRotate {
-            comp = resumeWithQueue comp.queue value;
+            comp = resumeCompOrValue comp.queue outerResume;
             inherit handlers state done;
-          } 0));
+          } 0)) // { __rawResume = true; });
 
   run = mk {
     doc = ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -108,7 +108,9 @@ in {
   inherit (scopeTests) twoUsersTest scopeStateIsolation scopeEscapeEffects nestedScopes
           scopeWithStatefulHandler scopeDoesNotCorruptUserState
           dynamicHandlerFromEffect abortInsideScope threeUsersFanOut
-          scopeOverrideInNested;
+          scopeOverrideInNested
+          deepHandlerEffectfulResume deepHandlerChainedResume
+          deepHandlerStatefulInner;
 
   inherit (streamTests) fromListToListTest fromListEmptyTest
           rangeTest rangeEmptyTest replicateTest replicateZeroTest

--- a/tests/scope-test.nix
+++ b/tests/scope-test.nix
@@ -168,6 +168,73 @@ let
     expected = { outer = "outer"; inner = "inner"; };
   };
 
+  # Deep handler semantics: when an effect rotates outward and the outer
+  # handler returns an effectful resume (a computation), the resume's
+  # effects should be caught by the inner scope's handlers first.
+  deepHandlerEffectfulResume = {
+    expr =
+      let
+        # Computation sends "B" (not in inner scope — rotates outward)
+        comp = bind (send "B" null) (x: pure x);
+
+        # Inner scope handles "A"
+        scoped = scope.run {
+          handlers.A = { param, state }: { resume = 42; inherit state; };
+        } comp;
+
+        # Outer handler for "B" returns effectful resume that sends "A"
+        result = handle {
+          handlers.B = { param, state }: {
+            resume = send "A" null;
+            inherit state;
+          };
+        } scoped;
+      in result.value;
+    # Deep: "A" caught by inner scope → 42
+    # Shallow: "A" handled at outer level → unhandled effect error
+    expected = 42;
+  };
+
+  # Deep handler semantics with chained effectful resume:
+  # outer handler returns bind (send "A" ...) (x: pure (x + 1))
+  # "A" should be caught by inner scope, then continuation runs
+  deepHandlerChainedResume = {
+    expr =
+      let
+        comp = bind (send "B" null) (x: pure x);
+        scoped = scope.run {
+          handlers.A = { param, state }: { resume = 100; inherit state; };
+        } comp;
+        result = handle {
+          handlers.B = { param, state }: {
+            resume = bind (send "A" null) (x: pure (x + 1));
+            inherit state;
+          };
+        } scoped;
+      in result.value;
+    expected = 101;
+  };
+
+  # Deep handler semantics with stateful inner scope:
+  # verify inner scope state is threaded correctly through effectful resume
+  deepHandlerStatefulInner = {
+    expr =
+      let
+        comp = bind (send "B" null) (x: pure x);
+        scoped = scope.runWith {
+          handlers.A = { param, state }: { resume = state; state = state + 1; };
+          state = 0;
+        } comp;
+        result = handle {
+          handlers.B = { param, state }: {
+            resume = bind (send "A" null) (_: send "A" null);
+            inherit state;
+          };
+        } scoped;
+      in result.value;
+    expected = { value = 1; state = 2; };
+  };
+
   allPass = twoUsersTest.expr == twoUsersTest.expected
     && scopeStateIsolation.expr == scopeStateIsolation.expected
     && scopeEscapeEffects.expr == scopeEscapeEffects.expected
@@ -177,11 +244,17 @@ let
     && dynamicHandlerFromEffect.expr == dynamicHandlerFromEffect.expected
     && abortInsideScope.expr == abortInsideScope.expected
     && threeUsersFanOut.expr == threeUsersFanOut.expected
-    && scopeOverrideInNested.expr == scopeOverrideInNested.expected;
+    && scopeOverrideInNested.expr == scopeOverrideInNested.expected
+    && deepHandlerEffectfulResume.expr == deepHandlerEffectfulResume.expected
+    && deepHandlerChainedResume.expr == deepHandlerChainedResume.expected
+    && deepHandlerStatefulInner.expr == deepHandlerStatefulInner.expected;
 
 in {
   inherit twoUsersTest scopeStateIsolation scopeEscapeEffects nestedScopes
           scopeWithStatefulHandler scopeDoesNotCorruptUserState
           dynamicHandlerFromEffect abortInsideScope threeUsersFanOut
-          scopeOverrideInNested allPass;
+          scopeOverrideInNested
+          deepHandlerEffectfulResume deepHandlerChainedResume
+          deepHandlerStatefulInner
+          allPass;
 }


### PR DESCRIPTION
Problem: when scope.run installs scoped handlers, effects not matching the scope rotate outward to the enclosing handler. If the outer handler returns an effectful resume (a computation), those resume effects were processed by the outer interpret loop — never re-entering the inner scope. Scoped handlers were invisible to effects originating from outer handler resumes.

Example: inner scope handles effect A. Computation sends effect B (not in inner scope). B rotates to outer handler. Outer handler for B returns resume = send "A" null. Previously, A was processed by the outer interpret (unhandled error). Now, A passes through the inner scope's handlers first.

Solution: three changes in the trampoline.

1. effectRotate/effectRotateSlow tag rotation continuations with __rawResume = true on the queue.

2. interpret checks __rawResume: if true, uses resumeWithQueue (passes raw resume to rotation continuation) instead of resumeCompOrValue (which would eagerly splice resume effects into the interpret loop).

3. The rotation continuation uses resumeCompOrValue to route the raw resume through effectRotate, where inner handlers get first opportunity to handle the effects. Non-matching effects re-rotate outward as before.

This implements deep handler semantics as described in the algebraic effects literature (Plotkin & Pretnar 2013, Koka, Eff, OCaml 5). Continuations now capture the full handler stack — when a handler resumes, the continuation runs with all handler layers still active.

Backwards compatible: all existing tests pass unchanged. 3 new scope tests validate deep handler behavior.

Authored-by: @sini 