### PR TITLE
feat(scope): add provide/val primitives, fix queue rawResume, optional bind args

### DIFF
--- a/src/binds.nix
+++ b/src/binds.nix
@@ -21,11 +21,21 @@ let
       toComp = name:
         let value = attrs.${name}; in
         if isComp value
-        then { inherit name value; }
-        else { inherit name; value = send name value; };
+        then { inherit name; comp = value; optional = false; }
+        else { inherit name; comp = send name value; optional = value == true; };
     in
     builtins.foldl'
-    (prev: curr: bind prev (acc: bind curr.value (result: pure (acc // { ${curr.name} = result; }))))
+    (prev: curr:
+      bind prev (acc:
+        if curr.optional then
+          # Optional arg: probe handler first, skip if absent (Nix default kicks in)
+          bind (send "has-handler" curr.name) (available:
+            if available then bind curr.comp (result: pure (acc // { ${curr.name} = result; }))
+            else pure acc
+          )
+        else
+          bind curr.comp (result: pure (acc // { ${curr.name} = result; }))
+      ))
     (pure {})
     (map toComp names);
 
@@ -38,6 +48,9 @@ let
     ```
 
     Values that are non-effects become send params: `send "foo" 99`.
+    Values of `true` (from `lib.functionArgs` optional args) are probed
+    via has-handler first — if no handler exists, the key is omitted
+    from the result so the Nix function's default kicks in.
 
     Result has same attr-keys with corresponding effect result.
 
@@ -103,8 +116,12 @@ let
     ```
 
     The function sees bar as the result of `pure 22` and `foo` as the
-    result of `send "foo" false` -- false comes directly from using 
+    result of `send "foo" false` -- false comes directly from using
     `lib.functionArgs f`, the handler can know if "foo" is optional in f.
+
+    Optional args (those with defaults in the Nix function) are probed
+    via has-handler before sending. If no handler exists, the arg is
+    skipped and the Nix default kicks in.
 
     This works by using `bindAttrs` on the intersection of function args
     and attrs.
@@ -127,6 +144,26 @@ let
          } null;
         in result.value;
         expected = 22;
+      };
+      optional-arg-skipped-when-no-handler = {
+        expr = let
+          eff = bindComp { } ({ x, y ? 99 }: pure (x + y));
+          result = fx.trampoline.run eff {
+            x = { param, state }: { resume = 1; inherit state; };
+            # no handler for y — optional, so Nix default (99) is used
+          } null;
+        in result.value;
+        expected = 100;
+      };
+      optional-arg-resolved-when-handler-exists = {
+        expr = let
+          eff = bindComp { } ({ x, y ? 99 }: pure (x + y));
+          result = fx.trampoline.run eff {
+            x = { param, state }: { resume = 1; inherit state; };
+            y = { param, state }: { resume = 2; inherit state; };
+          } null;
+        in result.value;
+        expected = 3;
       };
     };
   };
@@ -162,6 +199,25 @@ let
          } null;
         in result.value;
         expected = 22;
+      };
+      optional-arg-skipped-when-no-handler = {
+        expr = let
+          eff = bindFn { } ({ x, y ? 99 }: x + y);
+          result = fx.trampoline.run eff {
+            x = { param, state }: { resume = 1; inherit state; };
+          } null;
+        in result.value;
+        expected = 100;
+      };
+      optional-arg-resolved-when-handler-exists = {
+        expr = let
+          eff = bindFn { } ({ x, y ? 99 }: x + y);
+          result = fx.trampoline.run eff {
+            x = { param, state }: { resume = 1; inherit state; };
+            y = { param, state }: { resume = 2; inherit state; };
+          } null;
+        in result.value;
+        expected = 3;
       };
     };
   };

--- a/src/effects/scope.nix
+++ b/src/effects/scope.nix
@@ -4,10 +4,12 @@
 # user-visible state. Built on fx.rotate (Kyo-style handler rotation).
 #
 #
-# scope.stateful - Install handlers for subcomputation, preserving state around rotation.
-# scope.run    — run body with scoped handlers, hide scope state
-# scope.runWith — run body with scoped handlers, expose scope state
-# scope.handlersFromAttrs - helper for creating handlers from Nix attrsets
+# scope.provide  — install handlers for subtree, no state interaction (reader/val pattern)
+# scope.val      — convenience: provide constant values as named effects
+# scope.stateful — install handlers for subcomputation, preserving state around rotation
+# scope.run      — run body with scoped handlers, hide scope state
+# scope.runWith  — run body with scoped handlers, expose scope state
+# scope.handlersFromAttrs — helper for creating handlers from Nix attrsets
 { fx, api, lib, ... }:
 
 let
@@ -76,6 +78,177 @@ let
          } (send "foo" null));
         expected.state = 22;
         expected.value = 33;
+      };
+    };
+  };
+
+  provide = mk {
+    doc = ''
+      Install handlers for a computation's dynamic extent without
+      touching state. Unhandled effects rotate outward; outer handler
+      state mutations survive unaffected.
+
+      This is the reader/val handler pattern (Koka's `val`, Haskell's
+      `runReader`, Scheme's `parameterize`) — use it when handlers are
+      stateless (resume with a constant, pass state through).
+      For handlers that need their own state, use scope.run or
+      scope.stateful instead.
+
+      ```
+      scope.provide : handlers -> Computation a -> Computation a
+      ```
+    '';
+    value = handlers: body:
+      rotate { inherit handlers; return = value: _: value; } body;
+    tests = {
+      "provide-resolves-effect" = {
+        expr =
+          let
+            comp = send "x" null;
+            result = handle { handlers = {}; }
+              (provide {
+                x = { state, ... }: { resume = 42; inherit state; };
+              } comp);
+          in result.value;
+        expected = 42;
+      };
+      "provide-rotates-unhandled" = {
+        expr =
+          let
+            comp = send "outer" 7;
+            result = handle {
+              handlers.outer = { param, state }: { resume = param * 2; inherit state; };
+            } (provide {
+              inner = { state, ... }: { resume = 99; inherit state; };
+            } comp);
+          in result.value;
+        expected = 14;
+      };
+      "provide-preserves-outer-state" = {
+        expr =
+          let
+            comp = bind (send "count" null) (_: send "count" null);
+            result = handle {
+              handlers = {
+                count = { param, state }: {
+                  resume = null;
+                  state = state // { n = (state.n or 0) + 1; };
+                };
+              };
+              state = {};
+            } (provide {
+              x = { state, ... }: { resume = 42; inherit state; };
+            } comp);
+          in result.state.n;
+        expected = 2;
+      };
+      "provide-deep-semantics" = {
+        expr =
+          let
+            comp = bind (send "outer" null) (_: send "inner" null);
+            result = handle {
+              handlers.outer = { param, state }: {
+                resume = send "inner" null;
+                inherit state;
+              };
+            } (provide {
+              inner = { state, ... }: { resume = 42; inherit state; };
+            } comp);
+          in result.value;
+        expected = 42;
+      };
+      "provide-nested-shadow" = {
+        expr =
+          let
+            comp = send "x" null;
+            result = handle { handlers = {}; }
+              (provide {
+                x = { state, ... }: { resume = 1; inherit state; };
+              } (provide {
+                x = { state, ... }: { resume = 2; inherit state; };
+              } comp));
+          in result.value;
+        expected = 2;
+      };
+      "provide-empty-handlers" = {
+        expr =
+          let
+            comp = send "x" 21;
+            result = handle {
+              handlers.x = { param, state }: { resume = param * 2; inherit state; };
+            } (provide {} comp);
+          in result.value;
+        expected = 42;
+      };
+    };
+  };
+
+  val = mk {
+    doc = ''
+      Provide constant values as named effect handlers for a
+      computation's dynamic extent. Each key in the bindings attrset
+      becomes an effect that resumes with the corresponding value.
+      Built on scope.provide via handlersFromAttrs.
+
+      Named after Koka's `val` effect handler. For the traditional
+      single-environment reader (ask/asks/local), see fx.effects.reader.
+
+      ```
+      scope.val : AttrSet -> Computation a -> Computation a
+      ```
+    '';
+    value = bindings: body:
+      provide (handlersFromAttrs bindings) body;
+    tests = {
+      "val-provides-values" = {
+        expr =
+          let
+            comp = bind (send "host" null) (h: pure h.name);
+            result = handle { handlers = {}; }
+              (val { host = { name = "igloo"; }; } comp);
+          in result.value;
+        expected = "igloo";
+      };
+      "val-composes" = {
+        expr =
+          let
+            comp = bind (send "host" null) (h:
+              bind (send "user" null) (u:
+                pure "${h.name}-${u.name}"));
+            result = handle { handlers = {}; }
+              (val { host = { name = "igloo"; }; }
+                (val { user = { name = "tux"; }; } comp));
+          in result.value;
+        expected = "igloo-tux";
+      };
+      "val-state-transparent" = {
+        expr =
+          let
+            comp = bind (send "inc" 1) (_:
+              bind (send "host" null) (h:
+                bind (send "inc" 1) (_:
+                  pure h.name)));
+            result = handle {
+              handlers = {
+                inc = { param, state }: {
+                  resume = null;
+                  state = state // { n = (state.n or 0) + param; };
+                };
+              };
+              state = {};
+            } (val { host = { name = "igloo"; }; } comp);
+          in { n = result.state.n; value = result.value; };
+        expected = { n = 2; value = "igloo"; };
+      };
+      "val-nested-shadow" = {
+        expr =
+          let
+            comp = send "x" null;
+            result = handle { handlers = {}; }
+              (val { x = 1; }
+                (val { x = 2; } comp));
+          in result.value;
+        expected = 2;
       };
     };
   };
@@ -154,6 +327,6 @@ let
 in mk {
   doc = "Computation-scoped handlers via effect rotation.";
   value = { 
-    inherit stateful run runWith handlersFromAttrs; 
+    inherit provide val stateful run runWith handlersFromAttrs;
   };
 }

--- a/src/effects/scope.nix
+++ b/src/effects/scope.nix
@@ -180,6 +180,36 @@ let
           in result.value;
         expected = 42;
       };
+      # Deep semantics through bind chains: scope.provide inside a handler
+      # resume that is wrapped in fx.bind. The bind chain causes queue.append
+      # which must preserve __rawResume for deep handler routing.
+      "provide-deep-through-bind-chain" = {
+        expr =
+          let
+            # Outer handler for "work" resumes with a bind chain containing scope.provide.
+            # Inner scope shadows "probe" at root. "emit" rotates out, root handler
+            # resumes with "probe" — must route back through inner scope.
+            body = send "work" null;
+            result = handle {
+              handlers = {
+                probe = { state, ... }: { resume = "root"; inherit state; };
+                emit = { param, state }: {
+                  resume = send "probe" null;
+                  inherit state;
+                };
+                work = { param, state }: {
+                  # bind chain wraps scope.provide — exercises queue.append path
+                  resume = bind (pure null) (_:
+                    provide {
+                      probe = { state, ... }: { resume = "inner"; inherit state; };
+                    } (send "emit" null));
+                  inherit state;
+                };
+              };
+            } body;
+          in result.value;
+        expected = "inner";
+      };
     };
   };
 

--- a/src/queue.nix
+++ b/src/queue.nix
@@ -67,14 +67,15 @@ let
     value = q1: q2:
       if q1._variant == "Identity" then q2
       else if q2._variant == "Identity" then q1
-      else node q1 q2
-        # Preserve __rawResume flag through queue concatenation.
-        # effectRotate tags rotation continuations with __rawResume
-        # so the outer interpreter routes effectful resumes back
-        # through inner scope handlers (deep handler semantics).
-        # Without this, fx.bind chains around scope.provide lose
-        # the flag and deep semantics silently break.
-        // (if q1.__rawResume or false then { __rawResume = true; } else {});
+      # Preserve __rawResume flag through queue concatenation.
+      # effectRotate tags rotation continuations with __rawResume
+      # so the outer interpreter routes effectful resumes back
+      # through inner scope handlers (deep handler semantics).
+      # Without this, fx.bind chains around scope.provide lose
+      # the flag and deep semantics silently break.
+      else if q1.__rawResume or false
+      then (node q1 q2) // { __rawResume = true; }
+      else node q1 q2;
   };
 
   # -- Deconstruction --

--- a/src/queue.nix
+++ b/src/queue.nix
@@ -67,7 +67,14 @@ let
     value = q1: q2:
       if q1._variant == "Identity" then q2
       else if q2._variant == "Identity" then q1
-      else node q1 q2;
+      else node q1 q2
+        # Preserve __rawResume flag through queue concatenation.
+        # effectRotate tags rotation continuations with __rawResume
+        # so the outer interpreter routes effectful resumes back
+        # through inner scope handlers (deep handler semantics).
+        # Without this, fx.bind chains around scope.provide lose
+        # the flag and deep semantics silently break.
+        // (if q1.__rawResume or false then { __rawResume = true; } else {});
   };
 
   # -- Deconstruction --

--- a/tests/scope-test.nix
+++ b/tests/scope-test.nix
@@ -235,6 +235,66 @@ let
     expected = { value = 1; state = 2; };
   };
 
+  provideHostUser = {
+    expr =
+      let
+        comp = bind getUser (u:
+          bind getHost (h:
+            pure "${u}@${h}"));
+        result = handle { handlers = hostHandler; }
+          (scope.provide {
+            user = { state, ... }: { resume = "alice"; inherit state; };
+          } comp);
+      in result.value;
+    expected = "alice@myhost";
+  };
+
+  provideWithOuterState = {
+    expr =
+      let
+        comp = bind (send "count" null) (_:
+          bind getHost (h:
+            bind (send "count" null) (_:
+              pure h)));
+        result = handle {
+          handlers = hostHandler // {
+            count = { param, state }: {
+              resume = null;
+              state = state // { n = (state.n or 0) + 1; };
+            };
+          };
+          state = {};
+        } (scope.provide {
+          user = { state, ... }: { resume = "tux"; inherit state; };
+        } comp);
+      in { host = result.value; n = result.state.n; };
+    expected = { host = "myhost"; n = 2; };
+  };
+
+  valHostUser = {
+    expr =
+      let
+        comp = bind getUser (u:
+          bind getHost (h:
+            pure "${u}@${h}"));
+        result = handle { handlers = {}; }
+          (scope.val { host = "igloo"; user = "tux"; } comp);
+      in result.value;
+    expected = "tux@igloo";
+  };
+
+  valTwoUsers = {
+    expr =
+      let
+        comp =
+          bind (scope.val { user = "alice"; } greet) (a:
+          bind (scope.val { user = "bob"; } greet) (b:
+            pure { alice = a; bob = b; }));
+        result = handle { handlers = hostHandler; } comp;
+      in result.value;
+    expected = { alice = "alice@myhost"; bob = "bob@myhost"; };
+  };
+
   allPass = twoUsersTest.expr == twoUsersTest.expected
     && scopeStateIsolation.expr == scopeStateIsolation.expected
     && scopeEscapeEffects.expr == scopeEscapeEffects.expected
@@ -247,7 +307,11 @@ let
     && scopeOverrideInNested.expr == scopeOverrideInNested.expected
     && deepHandlerEffectfulResume.expr == deepHandlerEffectfulResume.expected
     && deepHandlerChainedResume.expr == deepHandlerChainedResume.expected
-    && deepHandlerStatefulInner.expr == deepHandlerStatefulInner.expected;
+    && deepHandlerStatefulInner.expr == deepHandlerStatefulInner.expected
+    && provideHostUser.expr == provideHostUser.expected
+    && provideWithOuterState.expr == provideWithOuterState.expected
+    && valHostUser.expr == valHostUser.expected
+    && valTwoUsers.expr == valTwoUsers.expected;
 
 in {
   inherit twoUsersTest scopeStateIsolation scopeEscapeEffects nestedScopes
@@ -256,5 +320,6 @@ in {
           scopeOverrideInNested
           deepHandlerEffectfulResume deepHandlerChainedResume
           deepHandlerStatefulInner
+          provideHostUser provideWithOuterState valHostUser valTwoUsers
           allPass;
 }


### PR DESCRIPTION
## Summary

- **scope.provide / scope.val** — stateless scoped handlers (reader pattern)
- **fix(queue):** preserve `__rawResume` through `queue.append`
- **feat(bind):** skip optional args when no handler exists

## scope.provide and scope.val

`scope.provide` installs handlers for a computation's dynamic extent without touching state (reader/val pattern). Unhandled effects rotate outward; outer handler state mutations survive unaffected.

`scope.val` is a convenience wrapper (named after Koka's `val` handler) that takes an attrset of constant values and builds handlers via `handlersFromAttrs`.

These fill a recognized gap between `scope.run` (isolated execution) and `scope.stateful` (state fork-join) for the common case of augmenting the handler environment with read-only bindings.

## fix(queue): preserve __rawResume through queue.append

`queue.append` creates a node attrset that lost the `__rawResume` flag set by `effectRotate` on rotation continuations. This broke deep handler semantics when `scope.provide` was used inside `fx.bind` chains — the outer interpreter fell back to `resumeCompOrValue` instead of `resumeWithQueue`, causing effectful resumes to bypass inner scope handlers.

## feat(bind): skip optional args when no handler exists

`bindAttrs` now probes `has-handler` for optional args before sending the effect. If no handler exists, the arg is omitted from the resolved attrset so the Nix function's default value kicks in.